### PR TITLE
feat: add delete sponsor functionality

### DIFF
--- a/lib/data/datasources/firebase_other_datasource.dart
+++ b/lib/data/datasources/firebase_other_datasource.dart
@@ -54,7 +54,11 @@ class FirebaseOtherDatasource implements OtherDatasource {
           .collection("sponsors")
           .orderBy("createdAt", descending: false)
           .get();
-      var info = res.docs.map((e) => Sponsor.fromJson(e.data())).toList();
+      var info = res.docs.map((e) {
+        final data = e.data();
+        data['id'] = e.id;
+        return Sponsor.fromJson(data);
+      }).toList();
       return info;
     } catch (e) {
       rethrow;
@@ -93,6 +97,15 @@ class FirebaseOtherDatasource implements OtherDatasource {
           .map((e) => TreasureHuntModel.fromJson(e.data()))
           .toList();
       return info;
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> deleteSponsor(String sponsorId) async {
+    try {
+      await _db.collection('sponsors').doc(sponsorId).delete();
     } catch (e) {
       rethrow;
     }

--- a/lib/data/repositories/other_repository_impl.dart
+++ b/lib/data/repositories/other_repository_impl.dart
@@ -35,4 +35,9 @@ class OtherRepositoryImpl implements OtherRepository {
   Future<List<TreasureHuntModel>> getTreasureHuntItems() {
     return _db.getTreasureHuntItems();
   }
+
+  @override
+  Future<void> deleteSponsor(String sponsorId) async {
+    await _db.deleteSponsor(sponsorId);
+  }
 }

--- a/lib/domain/datasources/other_datasource.dart
+++ b/lib/domain/datasources/other_datasource.dart
@@ -21,4 +21,7 @@ abstract class OtherDatasource {
 
   // List treasure hunt items
   Future<List<TreasureHuntModel>> getTreasureHuntItems();
+
+  /// Deletes a sponsor by id
+  Future<void> deleteSponsor(String sponsorId);
 }

--- a/lib/domain/repositories/other_repository.dart
+++ b/lib/domain/repositories/other_repository.dart
@@ -18,4 +18,7 @@ abstract class OtherRepository {
 
   /// List treasure hunt items
   Future<List<TreasureHuntModel>> getTreasureHuntItems();
+
+  /// Deletes a sponsor by id
+  Future<void> deleteSponsor(String sponsorId);
 }

--- a/lib/ui/providers/other_provider.dart
+++ b/lib/ui/providers/other_provider.dart
@@ -81,6 +81,18 @@ class OtherProvider with ChangeNotifier {
     }
   }
 
+  Future<void> deleteSponsor(String sponsorId) async {
+    loadingSponsor = true;
+    try {
+      await _otherRepository.deleteSponsor(sponsorId);
+      sponsors = await _otherRepository.getSponsors();
+    } catch (e) {
+      rethrow;
+    } finally {
+      loadingSponsor = false;
+    }
+  }
+
   Future<void> getTreasureHuntItems() async {
     try {
       loadingTreasureHunt = true;

--- a/lib/ui/widgets/home/sponsors_content.dart
+++ b/lib/ui/widgets/home/sponsors_content.dart
@@ -87,21 +87,97 @@ class _SponsorsContentState extends State<SponsorsContent> {
                       for (var item in dataCenter.sponsors)
                         Tooltip(
                           message: item.name,
-                          child: TextButton(
-                            onPressed: () async {
-                              await laucherUrlInfo(item.link);
-                            },
-                            child: Container(
-                              margin: const EdgeInsets.all(5),
-                              width: MediaQuery.of(context).size.width * 0.35,
-                              // height: MediaQuery.of(context).size.width * 0.35,
-                              child: FadeInImage(
-                                placeholder: const AssetImage(
-                                  AppAssetsPath.loadingSmallImage,
+                          child: Stack(
+                            children: [
+                              TextButton(
+                                onPressed: () async {
+                                  await laucherUrlInfo(item.link);
+                                },
+                                child: Container(
+                                  margin: const EdgeInsets.all(5),
+                                  width:
+                                      MediaQuery.of(context).size.width * 0.35,
+                                  child: FadeInImage(
+                                    placeholder: const AssetImage(
+                                      AppAssetsPath.loadingSmallImage,
+                                    ),
+                                    image: CachedNetworkImageProvider(
+                                      item.photoUrl,
+                                    ),
+                                  ),
                                 ),
-                                image: CachedNetworkImageProvider(item.photoUrl),
                               ),
-                            ),
+                              if (userProvider.isAdmin)
+                                Positioned(
+                                  top: 0,
+                                  right: 0,
+                                  child: IconButton(
+                                    onPressed: () async {
+                                      if (item.id == null) return;
+
+                                      final confirm = await showDialog<bool>(
+                                        context: context,
+                                        builder: (_) => AlertDialog(
+                                          title: const Text('Eliminar sponsor'),
+                                          content: Text(
+                                            '¿Estás seguro de eliminar a ${item.name}?',
+                                          ),
+                                          actions: [
+                                            TextButton(
+                                              onPressed: () => Navigator.of(
+                                                context,
+                                              ).pop(false),
+                                              child: const Text('Cancelar'),
+                                            ),
+                                            ElevatedButton(
+                                              style: ElevatedButton.styleFrom(
+                                                backgroundColor:
+                                                    AppStyles.colorBaseRed,
+                                              ),
+                                              onPressed: () => Navigator.of(
+                                                context,
+                                              ).pop(true),
+                                              child: const Text(
+                                                'Eliminar',
+                                                style: TextStyle(
+                                                  color: Colors.white,
+                                                ),
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      );
+
+                                      if (confirm != true) {
+                                        return;
+                                      }
+                                      if (!context.mounted) {
+                                        return;
+                                      }
+
+                                      showDialog(
+                                        context: context,
+                                        barrierDismissible: false,
+                                        builder: (_) => const Center(
+                                          child: CircularProgressIndicator(),
+                                        ),
+                                      );
+
+                                      await dataCenter.deleteSponsor(item.id!);
+
+                                      if (context.mounted) {
+                                        Navigator.of(
+                                          context,
+                                        ).pop();
+                                      }
+                                    },
+                                    icon: const Icon(
+                                      Icons.delete,
+                                      color: AppStyles.colorBaseRed,
+                                    ),
+                                  ),
+                                ),
+                            ],
                           ),
                         ),
                     ],


### PR DESCRIPTION
#51
- Add deleteSponsor method across all layers (datasource, repository, provider)
- Fix getSponsors to map Firestore document id to sponsor model
- Add confirmation dialog and loading indicator in sponsors_content.dart